### PR TITLE
Fix tray menu behavior on some platforms

### DIFF
--- a/client.js
+++ b/client.js
@@ -389,6 +389,12 @@ class Client {
             }
         }
     }
+
+    rebuildTrayMenu() {
+        // This function should be called after any modifications to the tray menu. 
+        // It's needed for the tray menu to behave correctly on Linux/Mac.
+        this.tray.setContextMenu(this.menuTray);
+    }
 }
 
 module.exports = Client;

--- a/client.js
+++ b/client.js
@@ -391,8 +391,6 @@ class Client {
     }
 
     rebuildTrayMenu() {
-        // This function should be called after any modifications to the tray menu. 
-        // It's needed for the tray menu to behave correctly on Linux/Mac.
         this.tray.setContextMenu(this.menuTray);
     }
 }

--- a/credentials/credentials.js
+++ b/credentials/credentials.js
@@ -170,6 +170,8 @@ class Credentials {
 
         this.client.menuTray.insert(3, new MenuItem({type: "separator"}));
 
+        this.client.rebuildTrayMenu();
+
         let config = {
             tooltip: "Darkorbit Client",
             tray: this.client.tray,

--- a/darkDev/darkDev.js
+++ b/darkDev/darkDev.js
@@ -28,6 +28,8 @@ class DarkDev {
             type: "separator"
         }));
 
+        this.client.rebuildTrayMenu();
+
         this.customLoad = new CustomLoad(this.client, this.window);
         this.customJs = new CustomJs(this.client, this.window);
         this.customCss = new CustomCss(this.client, this.window);

--- a/settings/settings.js
+++ b/settings/settings.js
@@ -16,7 +16,7 @@ class Settings {
             type: "separator"
         }));
 
-        this.client.tray.rebuildTrayMenu();
+        this.client.rebuildTrayMenu();
 
         ipcMain.on("LoadSettings", () => {
             this.window.webContents.send("SendLoadSettings", settings.getSync().Settings)

--- a/settings/settings.js
+++ b/settings/settings.js
@@ -6,6 +6,8 @@ class Settings {
         this.client = client;
         this.window;
 
+        console.log(this.client.menuTray)
+
         this.client.menuTray.insert(4, new MenuItem({
             label: "Settings",
             type: "normal",
@@ -15,6 +17,8 @@ class Settings {
         this.client.menuTray.insert(5, new MenuItem({
             type: "separator"
         }));
+
+        this.client.tray.rebuildTrayMenu();
 
         ipcMain.on("LoadSettings", () => {
             this.window.webContents.send("SendLoadSettings", settings.getSync().Settings)

--- a/settings/settings.js
+++ b/settings/settings.js
@@ -6,8 +6,6 @@ class Settings {
         this.client = client;
         this.window;
 
-        console.log(this.client.menuTray)
-
         this.client.menuTray.insert(4, new MenuItem({
             label: "Settings",
             type: "normal",


### PR DESCRIPTION
Hey,

as per https://github.com/electron/electron/issues/10951, on some platforms, the tray menu requires a rebuild in order for items to be added properly. I've been facing this issue on Linux/KDE where the options that get added later in the startup, such as settings, didn't show at all. 